### PR TITLE
Ignore files created when used as an external module in an autotools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 *.user
 *.db
 *.opendb
+# Ignore files created when used as an external module in an autotools project
+.deps/
+.dirstamp
+*.o

--- a/src/windows/DeviceINQ.cc
+++ b/src/windows/DeviceINQ.cc
@@ -5,6 +5,7 @@
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 
+#include <initguid.h>
 #include <windows.h>
 #include <string>
 #include <stdlib.h>


### PR DESCRIPTION
I use your project as a git submodule in one of my project, built with gnu autotools.
In such a case, some additional files have to be git-ignored.