### PR TITLE
Modern CMake, various small changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,9 @@ endif()
 
 # Platform-specific compile flags
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") # G++
-    target_compile_options(bluetoothserialport PUBLIC -Wall -Wextra)
+    target_compile_options(bluetoothserialport PRIVATE -Wall -Wextra)
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC") # MSVC
-    target_compile_options(bluetoothserialport PUBLIC /EHsc /W2 /c)
+    target_compile_options(bluetoothserialport PRIVATE /EHsc /W2 /c)
 endif()
 
 target_include_directories(bluetoothserialport

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Enums.cc
 )
 
-if(WIN32)
+if(WIN32) # windows
 	set(PLATFORM windows)
 	target_sources(bluetoothserialport
 	PRIVATE
@@ -38,6 +38,13 @@ else() # Linux
 		${CMAKE_CURRENT_SOURCE_DIR}/src/linux/DeviceINQ.cc
 	)
 	target_link_libraries(bluetoothserialport bluetooth)
+endif()
+
+# Platform-specific compile flags
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") # G++
+    target_compile_options(bluetoothserialport PUBLIC -Wall -Wextra)
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC") # MSVC
+    target_compile_options(bluetoothserialport PUBLIC /EHsc /W2 /c)
 endif()
 
 target_include_directories(bluetoothserialport

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,50 +1,51 @@
 project(bluetoothserialport)
 cmake_minimum_required(VERSION 3.1)
-
 set (CMAKE_CXX_STANDARD 11)
 
 add_library(bluetoothserialport)
 
+target_sources(bluetoothserialport
+PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/src/Enums.cc
+)
+
 if(WIN32)
+	set(PLATFORM windows)
 	target_sources(bluetoothserialport
 	PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BluetoothHelpers.cc
 		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BTSerialPortBinding.cc
 		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/DeviceINQ.cc
 	)
-	target_include_directories(bluetoothserialport
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/src/windows
-	)
 	target_link_libraries(bluetoothserialport ws2_32 bthprops)
 
-elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin") # MacOSX
+elseif(APPLE) # MacOSX
+	set(PLATFORM osx)
 	target_sources(bluetoothserialport
 	PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothDeviceResources.mm
 		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothWorker.mm
 		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BTSerialPortBinding.mm
-		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/DeviceINQ.mm src/osx/pipe.c
-	)
-	target_include_directories(bluetoothserialport
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/src/osx
+		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/DeviceINQ.mm
+		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/pipe.c
 	)
 	target_link_libraries(bluetoothserialport "-framework Foundation -framework IOBluetooth -fobjc-arc")
-else()
+else() # Linux
+	set(PLATFORM linux)
 	target_sources(bluetoothserialport
 	PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/src/linux/BTSerialPortBinding.cc
 		${CMAKE_CURRENT_SOURCE_DIR}/src/linux/DeviceINQ.cc
 	)
 	target_link_libraries(bluetoothserialport bluetooth)
-	target_include_directories(bluetoothserialport
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/src/linux
-	)
 endif()
 
-target_include_directories(bluetoothserialport PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(bluetoothserialport
+PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/src
+PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/src/${PLATFORM}
+)
 add_executable(inquiretest EXCLUDE_FROM_ALL ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)
 
 set_target_properties(bluetoothserialport

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,55 @@
 project(bluetoothserialport)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
-if (NOT MSVC)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-endif()
+set (CMAKE_CXX_STANDARD 11)
+
+add_library(bluetoothserialport)
 
 if(WIN32)
-	set(srcs src/Enums.cc src/windows/BluetoothHelpers.cc src/windows/BTSerialPortBinding.cc src/windows/DeviceINQ.cc)
-	include_directories(windows)
-	set(libs ws2_32 bthprops)
+	target_sources(bluetoothserialport
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BluetoothHelpers.cc
+		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BTSerialPortBinding.cc
+		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/DeviceINQ.cc
+	)
+	target_include_directories(bluetoothserialport
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/src/windows
+	)
+	target_link_libraries(bluetoothserialport ws2_32 bthprops)
+
 elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin") # MacOSX
-	set(srcs src/Enums.cc src/osx/BluetoothDeviceResources.mm src/osx/BluetoothWorker.mm src/osx/BTSerialPortBinding.mm src/osx/DeviceINQ.mm src/osx/pipe.c)
-	set(libs "-framework Foundation -framework IOBluetooth -fobjc-arc")
-	include_directories(osx)
+	target_sources(bluetoothserialport
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothDeviceResources.mm
+		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothWorker.mm
+		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BTSerialPortBinding.mm
+		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/DeviceINQ.mm src/osx/pipe.c
+	)
+	target_include_directories(bluetoothserialport
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/src/osx
+	)
+	target_link_libraries(bluetoothserialport "-framework Foundation -framework IOBluetooth -fobjc-arc")
 else()
-	set(srcs src/Enums.cc src/linux/BTSerialPortBinding.cc src/linux/DeviceINQ.cc)
-	set(libs bluetooth)
-	include_directories(linux)
+	target_sources(bluetoothserialport
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/src/linux/BTSerialPortBinding.cc
+		${CMAKE_CURRENT_SOURCE_DIR}/src/linux/DeviceINQ.cc
+	)
+	target_link_libraries(bluetoothserialport bluetooth)
+	target_include_directories(bluetoothserialport
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/src/linux
+	)
 endif()
 
-include_directories(./src)
-
-add_library(bluetoothserialport ${srcs})
-add_executable(inquiretest EXCLUDE_FROM_ALL test/main.cpp)
+target_include_directories(bluetoothserialport PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_executable(inquiretest EXCLUDE_FROM_ALL ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)
 
 set_target_properties(bluetoothserialport
 PROPERTIES
 	POSITION_INDEPENDENT_CODE ON
 )
 
-target_link_libraries(bluetoothserialport ${libs})
 target_link_libraries(inquiretest bluetoothserialport)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 include_directories(./src)
 
-add_library(bluetoothserialport STATIC ${srcs})
+add_library(bluetoothserialport SHARED ${srcs})
 add_executable(inquiretest EXCLUDE_FROM_ALL test/main.cpp)
 
 target_link_libraries(bluetoothserialport ${libs})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,13 @@ endif()
 
 include_directories(./src)
 
-add_library(bluetoothserialport SHARED ${srcs})
+add_library(bluetoothserialport ${srcs})
 add_executable(inquiretest EXCLUDE_FROM_ALL test/main.cpp)
+
+set_target_properties(bluetoothserialport
+PROPERTIES
+	POSITION_INDEPENDENT_CODE ON
+)
 
 target_link_libraries(bluetoothserialport ${libs})
 target_link_libraries(inquiretest bluetoothserialport)

--- a/src/BTSerialPortBinding.h
+++ b/src/BTSerialPortBinding.h
@@ -8,9 +8,9 @@ struct bluetooth_data;
 class BTSerialPortBinding
 {
 private:
-	std::unique_ptr<bluetooth_data> data;
 	std::string address;
 	int channelID;
+	std::unique_ptr<bluetooth_data> data;
 	//int readTimeout;
 	//int writeTimeout;
 	BTSerialPortBinding(std::string address, int channelID);

--- a/src/DeviceINQ.h
+++ b/src/DeviceINQ.h
@@ -30,6 +30,6 @@ private:
 public:
 	~DeviceINQ();
 	static DeviceINQ *Create();
-	std::vector<device> Inquire();
+	std::vector<device> Inquire(int length = 8);
 	int SdpSearch(std::string address);
 };

--- a/src/linux/DeviceINQ.cc
+++ b/src/linux/DeviceINQ.cc
@@ -4,8 +4,6 @@
 #include "BluetoothException.h"
 #include "DeviceINQ.h"
 
-#include <iostream>
-
 extern "C"{
 #include <stdio.h>
 #include <errno.h>
@@ -99,7 +97,6 @@ int DeviceINQ::SdpSearch(string address)
 	sdp_list_t *response_list = NULL, *search_list, *attrid_list;
 	sdp_session_t *session = 0;
 
-  std::cout << "Search started on address " << address << std::endl;
 	str2ba(address.c_str(), &target);
 
 	// connect to the SDP server running on the remote machine

--- a/src/linux/DeviceINQ.cc
+++ b/src/linux/DeviceINQ.cc
@@ -4,6 +4,8 @@
 #include "BluetoothException.h"
 #include "DeviceINQ.h"
 
+#include <iostream>
+
 extern "C"{
 #include <stdio.h>
 #include <errno.h>
@@ -97,6 +99,7 @@ int DeviceINQ::SdpSearch(string address)
 	sdp_list_t *response_list = NULL, *search_list, *attrid_list;
 	sdp_session_t *session = 0;
 
+  std::cout << "Search started on address " << address << std::endl;
 	str2ba(address.c_str(), &target);
 
 	// connect to the SDP server running on the remote machine
@@ -171,7 +174,6 @@ int DeviceINQ::SdpSearch(string address)
 
 		sdp_record_free(rec);
 	}
-
 	sdp_close(session);
 	return channelID;
 }

--- a/src/linux/DeviceINQ.cc
+++ b/src/linux/DeviceINQ.cc
@@ -40,7 +40,7 @@ DeviceINQ::~DeviceINQ()
 {
 }
 
-vector<device> DeviceINQ::Inquire()
+vector<device> DeviceINQ::Inquire(int length)
 {
 	char addr[19] = { 0 };
 	char name[248] = { 0 };
@@ -52,7 +52,7 @@ vector<device> DeviceINQ::Inquire()
 
 	int max_rsp = 255;
 	inquiry_info *ii = (inquiry_info*)malloc(max_rsp * sizeof(inquiry_info));
-	int num_rsp = hci_inquiry(dev_id, 8, max_rsp, NULL, &ii, IREQ_CACHE_FLUSH);
+	int num_rsp = hci_inquiry(dev_id, length, max_rsp, NULL, &ii, IREQ_CACHE_FLUSH);
 
 	vector<device> devices;
 

--- a/src/osx/DeviceINQ.mm
+++ b/src/osx/DeviceINQ.mm
@@ -41,8 +41,9 @@ DeviceINQ::~DeviceINQ()
 {
 }
 
-vector<device> DeviceINQ::Inquire()
+vector<device> DeviceINQ::Inquire(int length)
 {
+    (void)(length);
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     BluetoothWorker *worker = [BluetoothWorker getInstance];
 

--- a/src/windows/DeviceINQ.cc
+++ b/src/windows/DeviceINQ.cc
@@ -67,8 +67,9 @@ DeviceINQ::~DeviceINQ()
 		BluetoothHelpers::Finalize();
 }
 
-vector<device> DeviceINQ::Inquire()
+vector<device> DeviceINQ::Inquire(int length)
 {
+  (void)(length);
 	// Construct windows socket bluetooth variables
 	DWORD flags = LUP_CONTAINERS | LUP_FLUSHCACHE | LUP_RETURN_NAME | LUP_RETURN_ADDR;
 	DWORD querySetSize = sizeof(WSAQUERYSET);


### PR DESCRIPTION
After using this library in our own project, I found that the CMake left a lot to be desired. In particular, a lot of properties were set for the whole project and not just for their proper targets, PIC wasn't used (making it impossible to link bluetoothserialport with a shared library), lots of small stuff like that.

This may change the lib's build behavior in some edge cases, but I can't think of a way it would affect anything negatively at the moment.

Two other minor changes: I moved `std::unique_ptr<bluetooth_data> data` around to remove a warning from compilation and I added an optional parameter to `Inquire`. None of these should be breaking changes.

Oh and I added more compile warnings and a few compiler-specific flags. I don't recommend that these go in the platform-specific section.

These may not be the last changes I make to this project, but I feel like this is developed enough that it can be merged upstream if you're interested.

If you wanna read more about modern CMake practices there's a few nice articles about it, I like [this one](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/), there's also the Daniel Pfeifer's CMake bible that is his presentation on the topic, [Effective CMake](https://www.youtube.com/watch?v=bsXLMQ6WgIk).
There is more to do with this CMake, like a find module, I'll do it if I ever feel motivated to do so.