### PR TITLE
Index device list with standardized address.

### DIFF
--- a/src/osx/BluetoothWorker.mm
+++ b/src/osx/BluetoothWorker.mm
@@ -177,7 +177,7 @@
 			   	res.producer = producer;
 			   	res.channel = channel;
 
-			   	[devices setObject:res forKey:address];
+			   	[devices setObject:res forKey:[device addressString]];
 			}
 		}
 	}


### PR DESCRIPTION
The BT address can be formatted several ways (uppercase vs lowercase, mac BT inquiry returns aa-bb-cc... instead of the common aa:bb:cc), so standardize the format before looking for devices in the dictionary.