### PR TITLE
Bugfix/mac crash

### DIFF
--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -56,7 +56,7 @@ void BTSerialPortBinding::Connect()
     NSString *addressString = [NSString stringWithCString:address.c_str() encoding:NSASCIIStringEncoding];
     BluetoothWorker *worker = [BluetoothWorker getInstance];
     // create pipe to communicate with delegate
-    pipe_t *pipe = pipe_new(sizeof(int), 0);
+    pipe_t *pipe = pipe_new(sizeof(unsigned char), 0);
 
 	int status;
 

--- a/src/osx/BluetoothWorker.mm
+++ b/src/osx/BluetoothWorker.mm
@@ -333,7 +333,6 @@
 - (void)rfcommChannelData:(IOBluetoothRFCOMMChannel*)rfcommChannel data:(void *)dataPointer length:(size_t)dataLength
 {
 	NSString *address = [[rfcommChannel getDevice] addressString];
-	NSData *data = [NSData dataWithBytes: dataPointer length: dataLength];
 
 	while (![devicesLock tryLock]) {
 		CFRunLoopRun();
@@ -343,7 +342,7 @@
 
 	if (res != NULL && res.producer != NULL) {
 		// push the data into the pipe so it can be read from the main thread
-		pipe_push(res.producer, [data bytes], data.length);
+		pipe_push(res.producer, dataPointer, dataLength);
 	}
 
 	[devicesLock unlock];


### PR DESCRIPTION
This was hard to debug, because I couldn't run valgrind: the pipe is configured to use 4 byte elements. But since size are expected as number of elements and we are using bytes, this leads to reading random memory when filling the pipe. Likewise target buffers will overflow randomly.

The fix is trivial.