### PR TITLE
Modernize CMakeLists.txt to require CMake 3.10+ (fixes #22)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,68 +1,68 @@
-project(bluetoothserialport)
-cmake_minimum_required(VERSION 3.1)
-set (CMAKE_CXX_STANDARD 11)
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(VERSION 3.10)
+
+project(bluetoothserialport LANGUAGES CXX)
 
 add_library(bluetoothserialport)
 
-target_sources(bluetoothserialport
-PRIVATE
-	${CMAKE_CURRENT_SOURCE_DIR}/src/Enums.cc
+target_compile_features(bluetoothserialport PUBLIC cxx_std_11)
+
+target_sources(bluetoothserialport PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/Enums.cc
 )
 
-if(WIN32) # windows
-	set(PLATFORM windows)
-	target_sources(bluetoothserialport
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BluetoothHelpers.cc
-		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BTSerialPortBinding.cc
-		${CMAKE_CURRENT_SOURCE_DIR}/src/windows/DeviceINQ.cc
-	)
-	target_link_libraries(bluetoothserialport ws2_32 bthprops)
+if (WIN32)
+    set(PLATFORM windows)
+    target_sources(bluetoothserialport PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BluetoothHelpers.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/windows/BTSerialPortBinding.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/windows/DeviceINQ.cc
+    )
+    target_link_libraries(bluetoothserialport PRIVATE ws2_32 bthprops)
 
-elseif(APPLE) # MacOSX
-	set(PLATFORM osx)
-	target_sources(bluetoothserialport
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothDeviceResources.mm
-		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothWorker.mm
-		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BTSerialPortBinding.mm
-		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/DeviceINQ.mm
-		${CMAKE_CURRENT_SOURCE_DIR}/src/osx/pipe.c
-	)
-	find_library(FOUNDATION Foundation)
-	find_library(IOBLUETOOTH IOBluetooth)
-	target_link_libraries(bluetoothserialport ${FOUNDATION} ${IOBLUETOOTH} -fobjc-arc)
-	
-	add_executable(btScan src/osx/btScan.mm)
-	target_link_libraries(btScan ${FOUNDATION} ${IOBLUETOOTH})
-else() # Linux
-	set(PLATFORM linux)
-	target_sources(bluetoothserialport
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/src/linux/BTSerialPortBinding.cc
-		${CMAKE_CURRENT_SOURCE_DIR}/src/linux/DeviceINQ.cc
-	)
-	target_link_libraries(bluetoothserialport bluetooth)
+elseif (APPLE)
+    set(PLATFORM osx)
+    target_sources(bluetoothserialport PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothDeviceResources.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BluetoothWorker.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/osx/BTSerialPortBinding.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/osx/DeviceINQ.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/osx/pipe.c
+    )
+    find_library(FOUNDATION Foundation REQUIRED)
+    find_library(IOBLUETOOTH IOBluetooth REQUIRED)
+
+    target_compile_options(bluetoothserialport PRIVATE "-fobjc-arc")
+    target_link_libraries(bluetoothserialport PRIVATE ${FOUNDATION} ${IOBLUETOOTH})
+
+    add_executable(btScan src/osx/btScan.mm)
+    target_link_libraries(btScan PRIVATE ${FOUNDATION} ${IOBLUETOOTH})
+
+else()
+    set(PLATFORM linux)
+    target_sources(bluetoothserialport PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/linux/BTSerialPortBinding.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/linux/DeviceINQ.cc
+    )
+    target_link_libraries(bluetoothserialport PRIVATE bluetooth)
 endif()
 
 # Platform-specific compile flags
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") # G++
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(bluetoothserialport PRIVATE -Wall -Wextra)
-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC") # MSVC
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(bluetoothserialport PRIVATE /EHsc /W2 /c)
 endif()
 
 target_include_directories(bluetoothserialport
-PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}/src
-PRIVATE
-	${CMAKE_CURRENT_SOURCE_DIR}/src/${PLATFORM}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/${PLATFORM}
 )
+
+set_target_properties(bluetoothserialport PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 add_executable(inquiretest EXCLUDE_FROM_ALL ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)
+target_link_libraries(inquiretest PRIVATE bluetoothserialport ${FOUNDATION} ${IOBLUETOOTH})
 
-set_target_properties(bluetoothserialport
-PROPERTIES
-	POSITION_INDEPENDENT_CODE ON
-)
-
-target_link_libraries(inquiretest bluetoothserialport ${FOUNDATION} ${IOBLUETOOTH})


### PR DESCRIPTION
This PR updates the cmake_minimum_required() version to 3.10, suppresses compatibility errors on CMake 4.0+, and adopts modern CMake practices:

target_compile_features()
Scoped target_compile_options() and target_link_libraries()
Removed global CMAKE_CXX_STANDARD

Fixes #22.